### PR TITLE
Fix wat syntax so wasm tests pass (#199)

### DIFF
--- a/lib/wasm/tests/testsuite.rs
+++ b/lib/wasm/tests/testsuite.rs
@@ -23,6 +23,15 @@ fn testsuite() {
     let mut paths: Vec<_> = fs::read_dir("../../wasmtests")
         .unwrap()
         .map(|r| r.unwrap())
+        .filter(|p| {
+            // Ignore files starting with `.`, which could be editor temporary files
+            if let Some(stem) = p.path().file_stem() {
+                if let Some(stemstr) = stem.to_str() {
+                    return !stemstr.starts_with(".");
+                }
+            }
+            false
+        })
         .collect();
     paths.sort_by_key(|dir| dir.path());
     let flags = Flags::new(&settings::builder());
@@ -88,7 +97,7 @@ fn handle_module(path: PathBuf, flags: &Flags) {
                     }
                     read_wasm_file(file_path).expect("error reading converted wasm file")
                 }
-                None | Some(&_) => panic!("the file extension is not wasm or wat"),
+                None | Some(&_) => panic!("the file extension for {:?} is not wasm or wat", path),
             }
         }
     };

--- a/wasmtests/icall.wat
+++ b/wasmtests/icall.wat
@@ -1,7 +1,7 @@
 (module
   (type $ft (func (param f32) (result i32)))
   (func $foo (export "foo") (param i32 f32) (result i32)
-    (call_indirect $ft (get_local 1) (get_local 0))
+    (call_indirect (type $ft) (get_local 1) (get_local 0))
   )
   (table (;0;) 23 23 anyfunc)
 )


### PR DESCRIPTION
* wasm testsuite: ignore hidden files in test dir

and report a rejected file. it was picking up vim .swp files

* wasmtests: correct wat syntax in icall.wat